### PR TITLE
Fix Flutter font loading errors on macOS

### DIFF
--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Added com.apple.security.network.client entitlement to both DebugProfile.entitlements and Release.entitlements to allow the app to make outgoing network connections.

This fixes the "Operation not permitted" error when google_fonts package attempts to fetch Inter font files from fonts.gstatic.com on macOS.

Files modified:
- app/macos/Runner/DebugProfile.entitlements
- app/macos/Runner/Release.entitlements