### PR TITLE
Rename app to PRunner across all platforms

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
                      android:maxSdkVersion="30" />
 
     <application
-        android:label="app"
+        android:label="PRunner"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>App</string>
+	<string>PRunner</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>app</string>
+	<string>PRunner</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>PRunner</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/app/windows/runner/Runner.rc
+++ b/app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "app" "\0"
+            VALUE "FileDescription", "PRunner" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "app" "\0"
+            VALUE "InternalName", "PRunner" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "app.exe" "\0"
-            VALUE "ProductName", "app" "\0"
+            VALUE "OriginalFilename", "PRunner.exe" "\0"
+            VALUE "ProductName", "PRunner" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
Updated application display name from "app" to "PRunner" in platform-specific configuration files for Android, iOS, macOS, and Windows. This change only affects the visible app name; the Flutter icon remains unchanged.